### PR TITLE
libbanana: include stdlib.h

### DIFF
--- a/libbanana.c
+++ b/libbanana.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <libbanana.h>


### PR DESCRIPTION
The library uses calloc() which is defined in the standard library.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>